### PR TITLE
PR Labelling + Major Re-Writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 coverage
 lib
 .vscode
+tmp*

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,6 @@
+trailingComma: "es5"
+tabWidth: 2
+semi: true
+singleQuote: true
+arrowParens: always
+printWidth: 120

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sheriff",
   "version": "1.0.0",
   "private": true,
-  "description": "A Probot App that helps you maintain your repository",
+  "description": "A Probot App that helps you police your repository",
   "author": "ptvrajsk <ptvrajsk@gmail.com>",
   "license": "ISC",
   "homepage": "https://github.com/ptvrajsk/sheriff",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "build": "tsc -p ./tsconfig.json",
-    "start": "probot run ./lib/index.js",
+    "start": "npm run build && probot run ./lib/index.js",
     "test": "jest"
   },
   "dependencies": {

--- a/src/constants/const_labels.ts
+++ b/src/constants/const_labels.ts
@@ -1,0 +1,73 @@
+import LabelArchive from '../model/model_labelArchive';
+import Label, { LabelAction } from '../model/model_label';
+import LabelCollection, { LabelCollectionType } from '../model/model_labelCollection';
+
+export const LABEL_ARCHIVE: LabelArchive = new LabelArchive([
+  new LabelCollection(LabelCollectionType.IssueCollection, [
+    new Label(
+      `🐞 ${LabelCollectionType.IssueCollection}.Bug`,
+      'This issue describes a bug.',
+      'D73A4A',
+      'bug',
+      LabelAction.Bug
+    ),
+    new Label(
+      `⚙️ ${LabelCollectionType.IssueCollection}.Feature`,
+      'This issue describes a new feature.',
+      '120BB0',
+      'feature',
+      LabelAction.Feature
+    ),
+    new Label(
+      `📈 ${LabelCollectionType.IssueCollection}.Enhancement`,
+      'This issue describes an enhancement to an existing feature.',
+      '19504B',
+      'enhance',
+      LabelAction.Enhancement
+    ),
+    new Label(
+      `📚 ${LabelCollectionType.IssueCollection}.Documentation`,
+      'This issue describes a change to the existing documentation.',
+      '0075CA',
+      'doc',
+      LabelAction.Documentation
+    ),
+    new Label(
+      `❌ ${LabelCollectionType.IssueCollection}.WontFix`,
+      'This issue describes a suggestion that will not be fixed.',
+      'FFFFFF',
+      'wontfix',
+      LabelAction.WontFix
+    ),
+  ]),
+  new LabelCollection(LabelCollectionType.PRCollection, [
+    new Label(
+      `🏃 ${LabelCollectionType.PRCollection}.Ongoing`,
+      'This PR is still in progress.',
+      '2FEFDD',
+      ['progress', 'ongoing'],
+      LabelAction.OnGoing
+    ),
+    new Label(
+      `👍 ${LabelCollectionType.PRCollection}.ToMerge`,
+      'This PR is ready for merger.',
+      '0E8A16',
+      'merge',
+      LabelAction.ToMerge
+    ),
+    new Label(
+      `🔬 ${LabelCollectionType.PRCollection}.ToReview`,
+      'This PR is ready for review.',
+      'BA50EB',
+      'review',
+      LabelAction.ToReview
+    ),
+    new Label(
+      `🛑 ${LabelCollectionType.PRCollection}.OnHold`,
+      "This PR's progress is halted.",
+      'C5DEF5',
+      'hold',
+      LabelAction.Paused
+    ),
+  ]),
+]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,10 @@ export = (app: Probot) => {
     )
   })
 
+  app.on(["pull_request.opened", "pull_request.reopened"], async (context) => {
+    const repoOwnerData = context.repo();
+  })
+
   app.on("issues.opened", async (context) => {
     const issueComment = context.issue({
       body: "Thanks for opening this issue!",

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export = (app: Probot) => {
 
   app.on(["pull_request.opened", "pull_request.reopened"], async (context) => {
     const repoOwnerData = context.repo();
+    
   })
 
   app.on("issues.opened", async (context) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,60 +1,59 @@
-import { Probot } from "probot";
-import { LabelService } from "./services/labelService";
-import { OctokitLabelResponse } from "./services/labelService";
+import { Probot } from 'probot';
+import LabelService from './services/labelService';
+import PRService from './services/prService';
+import { PRAction } from './model/model_pr';
+import GHLabel from './model/model_ghLabel';
+import ContextService, { HookContext } from './services/contextService';
 
 const labelService: LabelService = new LabelService();
 
 export = (app: Probot) => {
 
-  app.on(['issues', 'pull_request', 'label'], async(context) => {
+  app.on(['pull_request.opened', 'pull_request.reopened', 'pull_request.ready_for_review'], async (context: HookContext) => {
+    PRService.replaceExistingPRLabels(
+      ContextService.getPRLabelReplacer(context),
+      context?.payload?.pull_request?.labels,
+      PRAction.READY_FOR_REVIEW
+    );
+  });
+
+  /**
+   * Unfortunately there isn't a pre-defined hook for
+   * some PR actions (i.e. Convert to draft) so this callback
+   * can be used to run processes for those actions.
+   */
+  app.on(['pull_request'], async (context: HookContext) => {
+    // 'as string' is necessary to prevent type checking
+    switch (context.payload.action as string) {
+      case 'converted_to_draft':
+        PRService.replaceExistingPRLabels(
+          ContextService.getPRLabelReplacer(context),
+          context?.payload?.pull_request?.labels,
+          PRAction.CONVERTED_TO_DRAFT
+        );
+        break;
+    }
+  });
+
+  app.on(['issues', 'pull_request', 'label'], async (context: HookContext) => {
     const octokitResponse = await context.octokit.issues.listLabelsForRepo(context.repo());
-    const repoOwnerData = context.repo();
-    const labelCreator: (name: string, desc: string, color: string) => Promise<any> = 
-      async (name: string, desc: string, color: string) => await context
-        .octokit
-        .rest
-        .issues
-        .createLabel(
-          {
-            ...repoOwnerData,
-            name: name,
-            description: desc,
-            color: color
-          }
-    );
+
+    const labelCreator: (name: string, desc: string, color: string) => Promise<any> =
+      ContextService.getLabelCreator(context);
     const labelUpdater: (oldName: string, newName: string, desc: string, color: string) => Promise<any> =
-      async (oldName: string, newName: string, desc: string, color: string) => await context
-        .octokit
-        .rest
-        .issues
-        .updateLabel(
-          {
-            ...repoOwnerData,
-            name: oldName,
-            new_name: newName,
-            description: desc,
-            color: color
-          }
-    );
+      ContextService.getLabelUpdater(context);
+
     labelService.generateMissingLabels(
-      labelService.updateLabels(
-        octokitResponse.data as OctokitLabelResponse[],
-        labelUpdater
-      ),
+      labelService.updateLabels(octokitResponse.data as GHLabel[], labelUpdater),
       labelCreator
-    )
-  })
+    );
+  });
 
-  app.on(["pull_request.opened", "pull_request.reopened"], async (context) => {
-    const repoOwnerData = context.repo();
-    
-  })
-
-  app.on("issues.opened", async (context) => {
+  app.on('issues.opened', async (context: HookContext) => {
     const issueComment = context.issue({
-      body: "Thanks for opening this issue!",
+      body: 'Thanks for opening this issue!',
     });
-    
+
     await context.octokit.issues.createComment(issueComment);
   });
   // For more information on building apps:

--- a/src/model/model_ghLabel.ts
+++ b/src/model/model_ghLabel.ts
@@ -1,0 +1,12 @@
+/**
+ * Label Model returned from GH (Octokit).
+ */
+export default interface GHLabel {
+  id: number,
+  node_id: string,
+  url: string,
+  name: string,
+  color: string,
+  default: boolean,
+  description: string
+}

--- a/src/model/model_label.ts
+++ b/src/model/model_label.ts
@@ -1,0 +1,69 @@
+import { createHash } from 'crypto';
+
+/**
+ * Enum exists as an accessible Identification
+ * for each created label.
+ * NOTE: Each LabelAction is unique and can only
+ * be assigned once to a Label.
+ */
+export enum LabelAction {
+  ToReview = 'To Review',
+  ToMerge = 'To Merge',
+  OnGoing = 'On Going',
+  Paused = 'OnHold',
+  Bug = 'Bug',
+  WontFix = 'Wont Fix',
+  Feature = 'Feature',
+  Documentation = 'Documentation',
+  Enhancement = 'Enhancement',
+}
+
+export default class Label {
+  private _name: string;
+  private _desc: string;
+  private _color: string;
+  private _identifier: string;
+  private _aliases: string[];
+  private _action: LabelAction;
+
+  constructor(name: string, desc: string, color: string, substr: string | string[], action: LabelAction) {
+    this._name = name;
+    this._desc = desc;
+    this._color = color;
+    this._identifier = Label.GenerateIdentifier(name, desc, color);
+    this._aliases = (typeof substr === 'string' || substr instanceof String ? [substr] : substr) as string[];
+    this._action = action;
+  }
+
+  public static GenerateIdentifier(name: string, desc: string, color: string) {
+    const hash = createHash('sha256');
+    hash.update(name);
+    hash.update(desc);
+    hash.update(color);
+    return hash.digest('hex');
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  public get desc(): string {
+    return this._desc;
+  }
+
+  public get color(): string {
+    return this._color;
+  }
+
+  public get identifier(): string {
+    return this._identifier;
+  }
+
+  public get labelAlias(): string[] {
+    return this._aliases;
+  }
+
+  public get action(): LabelAction {
+    return this._action;
+  }
+}

--- a/src/model/model_labelArchive.ts
+++ b/src/model/model_labelArchive.ts
@@ -1,0 +1,45 @@
+import Label, { LabelAction } from './model_label';
+import LabelCollection, { LabelCollectionType } from './model_labelCollection'
+
+export default class LabelArchive {
+  private _labelCollections: LabelCollection[];
+
+  constructor(labelCollections: LabelCollection[]) {
+    this._labelCollections = labelCollections;
+  }
+
+  public collatePresetSubstrings(): Map<string[], Label> {
+    const presetSubstrMap: Map<string[], Label> = new Map();
+    this._labelCollections.forEach((labelCollection: LabelCollection) => {
+      labelCollection.allLabels.forEach((label: Label) => {
+        presetSubstrMap.set(label.labelAlias, label);
+      });
+    });
+    return presetSubstrMap;
+  }
+
+  public collatePresetLabels(): Label[] {
+    return this._labelCollections.flatMap((labelCollection: LabelCollection) => {
+      return labelCollection.allLabels;
+    });
+  }
+
+  /**
+   * Searches and returns a specified label.
+   * @param labelCollectionType - Identifier for collection to search for label in.
+   * @param labelAction - Identifier for label.
+   * @returns Returns label that was found from identifiers.
+   * @throws Error if label is not found.
+   */
+  public getLabel(labelCollectionType: LabelCollectionType, labelAction: LabelAction): Label | undefined {
+    const foundLabel: Label | undefined = this._labelCollections
+      .find((labelCollection: LabelCollection) => labelCollection.collectionType === labelCollectionType)
+      ?.getLabel(labelAction);
+
+    if (!foundLabel) {
+      console.error(`No Label Error: Label -> ${labelAction} from collection ${labelCollectionType} does not exist.`);
+    }
+
+    return foundLabel;
+  }
+}

--- a/src/model/model_labelCollection.ts
+++ b/src/model/model_labelCollection.ts
@@ -1,0 +1,42 @@
+import Label, { LabelAction } from './model_label';
+
+export enum LabelCollectionType {
+  IssueCollection = 'issue',
+  PRCollection = 'pr',
+}
+
+export default class LabelCollection {
+  private _collectionType: LabelCollectionType;
+  private _labels: Label[];
+
+  constructor(collectionType: LabelCollectionType, labels: Label[]) {
+    this._collectionType = collectionType;
+    this._labels = this.getValidatedLabels(labels);
+  }
+
+  private getValidatedLabels(labels: Label[]): Label[] {
+    const labelActionSet: Set<string> = new Set<string>();
+    const verifiedLabels: Label[] = [];
+    for (const label of labels) {
+      if (labelActionSet.has(label.action)) {
+        console.error(`${label.action} has been defined before.`);
+      } else {
+        labelActionSet.add(label.action);
+        verifiedLabels.push(label);
+      }
+    }
+    return verifiedLabels;
+  }
+
+  public get collectionType(): LabelCollectionType {
+    return this._collectionType;
+  }
+
+  public getLabel(labelAction: LabelAction): Label | undefined {
+    return this._labels.find((label: Label) => label.action === labelAction);
+  }
+
+  public get allLabels(): Label[] {
+    return this._labels;
+  }
+}

--- a/src/model/model_pr.ts
+++ b/src/model/model_pr.ts
@@ -1,0 +1,6 @@
+export enum PRAction {
+  READY_FOR_REVIEW = 'Ready for Review',
+  CLOSED = 'Closed',
+  OPENED = 'Opened',
+  CONVERTED_TO_DRAFT = 'Converted to Draft',
+}

--- a/src/services/contextService.ts
+++ b/src/services/contextService.ts
@@ -1,0 +1,61 @@
+import { Context, WebhookPayloadWithRepository } from 'probot';
+
+/**
+ * Meant to help abbreviate context object type.
+ */
+export interface HookContext extends Context<WebhookPayloadWithRepository> {}
+
+interface RepoOwnerData {
+  owner: string;
+  repo: string;
+}
+
+export default class ContextService {
+  private static getRepoOwnerData(context: HookContext): RepoOwnerData {
+    return context.repo();
+  }
+
+  public static getLabelCreator(context: HookContext): (name: string, desc: string, color: string) => Promise<any> {
+    return async (name: string, desc: string, color: string) =>
+      await context.octokit.rest.issues.createLabel({
+        ...ContextService.getRepoOwnerData(context),
+        name: name,
+        description: desc,
+        color: color,
+      });
+  }
+
+  public static getLabelUpdater(
+    context: HookContext
+  ): (oldName: string, newName: string, desc: string, color: string) => Promise<any> {
+    return async (oldName: string, newName: string, desc: string, color: string) =>
+      await context.octokit.rest.issues.updateLabel({
+        ...ContextService.getRepoOwnerData(context),
+        name: oldName,
+        new_name: newName,
+        description: desc,
+        color: color,
+      });
+  }
+
+  public static getPRLabelReplacer(
+    context: HookContext
+  ): (removalLabelName: string[], replacementLabelNames: string[]) => void {
+    return async (removalLabelName: string[], replacementLabelNames: string[]) => {
+      const repoOwnerData: RepoOwnerData = ContextService.getRepoOwnerData(context);
+      for (const removalName of removalLabelName) {
+        await context.octokit.rest.issues.removeLabel({
+          ...repoOwnerData,
+          issue_number: context.payload.pull_request?.number!,
+          name: removalName,
+        });
+      }
+
+      await context.octokit.rest.issues.addLabels({
+        ...repoOwnerData,
+        issue_number: context.payload.pull_request?.number!,
+        labels: replacementLabelNames,
+      });
+    };
+  }
+}

--- a/src/services/labelService.ts
+++ b/src/services/labelService.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto';
 
-class Label {
+export class Label {
     private _labelName: string;
     private _labelDesc: string;
     private _labelColor: string;
@@ -62,7 +62,7 @@ class LabelCollection {
     }
 }
 
-const LABELS_COLLECTIONS: LabelCollection[] = [
+export const LABELS_COLLECTIONS: LabelCollection[] = [
     new LabelCollection(
         'Issue Labels',
         [

--- a/src/services/labelService.ts
+++ b/src/services/labelService.ts
@@ -1,243 +1,104 @@
-import { createHash } from 'crypto';
+import GHLabel from '../model/model_ghLabel';
+import Label, { LabelAction } from '../model/model_label';
+import { LabelCollectionType } from '../model/model_labelCollection';
+import { PRAction } from '../model/model_pr';
+import { LABEL_ARCHIVE } from '../constants/const_labels';
 
-/**
- * Enum exists as an accessible Identification
- * for each created label.
- * NOTE: Each LabelAction is unique and can only
- * be assigned once to a Label.
- */
-enum LabelActions {
-  ToReview = 'To Review',
-  ToMerge = 'To Merge',
-  WIP = 'WIP', // Work-In-Progress
-  Paused = 'OnHold',
-  Bug = 'Bug',
-  WontFix = 'Wont Fix',
-  Feature = 'Feature',
-  Documentation = 'Documentation',
-  Enhancement = 'Enhancement'
-}
+export default class LabelService {
+  /**
+   * Updates any existing labels that match the set of preset labels.
+   * @param octokitLabelsFetchResponse - Label data fetched from Github
+   * @param labelCreator - Callback function that allows for Label creation on Github.
+   * @param labelUpdater - Callback function that allows for label updating on Github.
+   * @returns List of updated Labels.
+   */
+  public updateLabels(
+    octokitLabelsFetchResponse: GHLabel[],
+    labelUpdater: (oldName: string, newName: string, desc: string, color: string) => Promise<any>
+  ): Label[] {
+    let remainingLabels: Label[] = LABEL_ARCHIVE.collatePresetLabels();
+    const presetSubstrIdentifiers: Map<string[], Label> = LABEL_ARCHIVE.collatePresetSubstrings();
+    presetSubstrIdentifiers.forEach((label: Label, substrings: string[]) => {
+      for (const substr of substrings) {
+        let isMatched = false;
 
-export class Label {
-  private _labelName: string;
-  private _labelDesc: string;
-  private _labelColor: string;
-  private _labelIdentifier: string;
-  private _labelAliases: string[];
-  private _labelAction: LabelActions;
+        for (const labelResponseIndex in octokitLabelsFetchResponse) {
+          if (octokitLabelsFetchResponse[labelResponseIndex].name.toLowerCase().includes(substr)) {
+            isMatched = true;
 
-  constructor(labelName: string, labelDesc: string, labelColor: string, labelSubstr: string | string[], labelAction: LabelActions) {
-    this._labelName = labelName;
-    this._labelDesc = labelDesc;
-    this._labelColor = labelColor;
-    this._labelIdentifier = Label.GenerateIdentifier(labelName, labelDesc, labelColor);
-    this._labelAliases = ((typeof labelSubstr === 'string' || labelSubstr instanceof String) ? [labelSubstr] : labelSubstr) as string[]; 
-    this._labelAction = labelAction;
+            if (this.doesLabelNeedUpdating(label, octokitLabelsFetchResponse[labelResponseIndex])) {
+              labelUpdater(octokitLabelsFetchResponse[labelResponseIndex].name, label.name, label.desc, label.color);
+            }
+
+            octokitLabelsFetchResponse.splice(+labelResponseIndex, 1);
+            remainingLabels = remainingLabels.filter((labelFromAll: Label) => labelFromAll.name !== label.name);
+            break;
+          }
+        }
+        if (isMatched) {
+          break;
+        }
+      }
+    });
+
+    return remainingLabels;
   }
 
-  public static GenerateIdentifier(labelName: string, labelDesc: string, labelColor: string) {
-    const hash = createHash('sha256');
-    hash.update(labelName);
-    hash.update(labelDesc);
-    hash.update(labelColor);
-    return hash.digest('hex');
+  private doesLabelNeedUpdating(comparisonLabel: Label, labelResponse: GHLabel): boolean {
+    return !(
+      comparisonLabel.name === labelResponse.name &&
+      comparisonLabel.desc === labelResponse.description &&
+      comparisonLabel.color === labelResponse.color
+    );
   }
 
-  public get labelName(): string {
-    return this._labelName;
+  /**
+   * Creates remaining missing labels on Github.
+   * @param remainingLabels - Labels that are missing from Github.
+   * @param labelCreator - Callback function that enables Label Creation.
+   */
+  public generateMissingLabels(
+    remainingLabels: Label[],
+    labelCreator: (name: string, desc: string, color: string) => Promise<any>
+  ): void {
+    remainingLabels.forEach(
+      async (label: Label) =>
+        await labelCreator(label.name, label.desc, label.color).catch(() =>
+          console.log(`Error in creating ${label.name}?`)
+        )
+    );
   }
 
-  public get labelDesc(): string {
-    return this._labelDesc;
+  public getPRLabelNames(prAction: PRAction): string[] {
+    const labelNames: string[] = [];
+
+    switch (prAction) {
+      case PRAction.CONVERTED_TO_DRAFT:
+      case PRAction.OPENED:
+        const onGoingLabel = LABEL_ARCHIVE.getLabel(LabelCollectionType.PRCollection, LabelAction.OnGoing);
+        if (onGoingLabel) {
+          labelNames.push(onGoingLabel.name);
+        }
+        break;
+
+      case PRAction.READY_FOR_REVIEW:
+        const toReviewLabel = LABEL_ARCHIVE.getLabel(LabelCollectionType.PRCollection, LabelAction.ToReview);
+        if (toReviewLabel) {
+          labelNames.push(toReviewLabel.name);
+        }
+        break;
+    }
+
+    return labelNames;
   }
 
-  public get labelColor(): string {
-    return this._labelColor;
-  }
-
-  public get labelIdentifier(): string {
-    return this._labelIdentifier;
-  }
-
-  public get labelAlias(): string[] {
-    return this._labelAliases;
-  }
-
-  public get labelAction(): LabelActions {
-    return this._labelAction;
-  }
-}
-
-enum LabelCollectionType {
-  IssueCollection = 'Issue Labels',
-  PRCollection = 'PR Labels'
-}
-
-class LabelCollection {
-
-  private _collectionType: LabelCollectionType;
-  private _labels: Label[];
-
-  constructor(collectionType: LabelCollectionType, labels: Label[]) {
-    this._collectionType = collectionType;
-    this._labels = this.getValidatedLabels(labels);
-  }
-
-  private getValidatedLabels(labels: Label[]): Label[] {
-    const labelActionSet: Set<string> = new Set<string>();
-    const verifiedLabels: Label[] = [];
-    for (const label of labels) {
-      if (labelActionSet.has(label.labelAction)) {
-        console.error(`${label.labelAction} has been defined before.`)
-      } else {
-        labelActionSet.add(label.labelAction);
-        verifiedLabels.concat(label);
+  public static extractLabelNames(labelCollectionType: LabelCollectionType, ghLabels: GHLabel[]) {
+    const labelNames: string[] = [];
+    for (const label of ghLabels) {
+      if (label.name.includes(`${labelCollectionType}.`)) {
+        labelNames.push(label.name);
       }
     }
-    return verifiedLabels;
+    return labelNames;
   }
-
-  public get collectionType(): string {
-    return this._collectionType;
-  }
-
-  public get labels(): Label[] {
-    return this._labels;
-  }
-}
-
-class LabelArchive {
-
-  private _labelCollections: LabelCollection[];
-
-  constructor(labelCollections: LabelCollection[]) {
-    this._labelCollections = labelCollections;
-  }
-
-  public collatePresetSubstrings(): Map<string[], Label> {
-    const presetSubstrMap: Map<string[], Label> = new Map();
-    this._labelCollections.forEach((labelCollection: LabelCollection) => {
-      labelCollection.labels.forEach((label: Label) => {
-        presetSubstrMap.set(label.labelAlias, label);
-      });
-    })
-    return presetSubstrMap;
-  }
-
-  public collatePresetLabels(): Label[] {
-    return this._labelCollections.flatMap((labelCollection: LabelCollection) => {
-        return labelCollection.labels;
-    });
-  }
-
-  public getLabel(labelCollectionType: LabelCollectionType, labelAction: LabelActions): Label {
-    const filteredLabels: Label[] = this._labelCollections
-      .filter((labelCollection: LabelCollection) => labelCollection.collectionType === labelCollectionType)
-      .flatMap((labelCollection: LabelCollection) => {
-        return labelCollection.labels.filter((label: Label) => label.labelAction === labelAction);
-    });
-    
-    if (filteredLabels.length === 0 || !filteredLabels) {
-      console.error(`No Label Error: Label -> ${labelAction} from collection ${labelCollectionType} does not exist.`);
-    } else if (filteredLabels.length > 1) {
-      console.error(`Label Collection Definition Error: Multiple Labels -> ${labelAction} from collection ${labelCollectionType} found.`);
-    }
-
-    return filteredLabels[0];
-  }
-}
-
-export const LABEL_ARCHIVE: LabelArchive = new LabelArchive(
-  [
-    new LabelCollection(
-      LabelCollectionType.IssueCollection,
-        [
-            new Label('🐞 issue.Bug', 'This issue describes a bug.', 'D73A4A', 'bug', LabelActions.Bug),
-            new Label('⚙️ issue.Feature', 'This issue describes a new feature.', '120BB0', 'feature', LabelActions.Feature),
-            new Label('📈 issue.Enhancement', 'This issue describes an enhancement to an existing feature.', '19504B', 'enhance', LabelActions.Enhancement),
-            new Label('📚 issue.Documentation', 'This issue describes a change to the existing documentation.', '0075CA', 'doc', LabelActions.Documentation),
-            new Label('❌ issue.WontFix', 'This issue describes a suggestion that will not be fixed.', 'FFFFFF', 'wontfix', LabelActions.WontFix)
-        ]
-    ),
-    new LabelCollection(
-      LabelCollectionType.PRCollection,
-        [
-            new Label('🏃 pr.Ongoing', 'This PR is still in progress.', '2FEFDD', ['progress', 'ongoing'], LabelActions.WIP),
-            new Label('👍 pr.ToMerge', 'This PR is ready for merger.', '0E8A16', 'merge', LabelActions.ToMerge),
-            new Label('🔬 pr.ToReview', 'This PR is ready for review.', 'BA50EB', 'review', LabelActions.ToReview),
-            new Label('🛑 pr.OnHold', 'This PR\'s progress is halted.', 'C5DEF5', 'hold', LabelActions.Paused)
-        ]
-    )
-  ]
-);
-
-export interface OctokitLabelResponse {
-    name: string;
-    description: string;
-    color: string;
-}
-
-export class LabelService {
-
-    /**
-     * Updates any existing labels that match the set of preset labels.
-     * @param octokitLabelsFetchResponse - Label data fetched from Github
-     * @param labelCreator - Callback function that allows for Label creation on Github.
-     * @param labelUpdater - Callback function that allows for label updating on Github.
-     * @returns List of updated Labels.
-     */
-    public updateLabels(octokitLabelsFetchResponse: OctokitLabelResponse[],
-        labelUpdater: (oldName: string, newName: string, desc: string, color: string) => Promise<any>
-        ): Label[] {
-        
-        let remainingLabels: Label[] = LABEL_ARCHIVE.collatePresetLabels();
-        const presetSubstrIdentifiers: Map<string[], Label> = LABEL_ARCHIVE.collatePresetSubstrings();
-        presetSubstrIdentifiers.forEach((label:Label, substrings: string[]) => {
-            for (const substr of substrings) {
-                let isMatched = false;
-                
-                for(const labelResponseIndex in octokitLabelsFetchResponse) {
-
-                    if(octokitLabelsFetchResponse[labelResponseIndex].name.toLowerCase().includes(substr)) {
-                        
-                        isMatched = true;
-
-                        if (this.doesLabelNeedUpdating(label, octokitLabelsFetchResponse[labelResponseIndex])) {
-                            labelUpdater(octokitLabelsFetchResponse[labelResponseIndex].name, label.labelName, label.labelDesc, label.labelColor);   
-                        }
-
-                        octokitLabelsFetchResponse.splice(+labelResponseIndex, 1);
-                        remainingLabels = remainingLabels.filter((labelFromAll: Label) => labelFromAll.labelName !== label.labelName);
-                        break;
-                    }
-                }
-                if (isMatched) {
-                    break;
-                }
-            };
-        });
-        
-        return remainingLabels;
-    }
-
-    private doesLabelNeedUpdating(comparisonLabel: Label, labelResponse: OctokitLabelResponse): boolean {
-        return !(comparisonLabel.labelName === labelResponse.name
-            && comparisonLabel.labelDesc === labelResponse.description
-            && comparisonLabel.labelColor === labelResponse.color);
-    }
-
-    /**
-     * Creates remaining missing labels on Github.
-     * @param remainingLabels - Labels that are missing from Github.
-     * @param labelCreator - Callback function that enables Label Creation.
-     */
-    public generateMissingLabels(remainingLabels: Label[],
-        labelCreator: (name: string, desc: string, color: string) => Promise<any>
-    ): void {
-
-        remainingLabels.forEach(async (label: Label) => 
-            await labelCreator(label.labelName, label.labelDesc, label.labelColor)
-                .catch(() => console.log(`Error in creating ${label.labelName}?`))
-        );
-    }
 }

--- a/src/services/prService.ts
+++ b/src/services/prService.ts
@@ -1,9 +1,31 @@
-import { Label } from './labelService';
+import GHLabel from '../model/model_ghLabel';
+import { LabelAction } from '../model/model_label';
+import LabelService from './labelService';
+import { LabelCollectionType } from '../model/model_labelCollection';
+import { LABEL_ARCHIVE } from '../constants/const_labels';
+import { PRAction } from '../model/model_pr';
 
-export class PRService {
-
-    public assignLabel(label: Label | Label[], prLabeller: (s: string) => void) {
-
+export default class PRService {
+  public static replaceExistingPRLabels(
+    labelReplacer: (removalLabelName: string[], replacementLabelNames: string[]) => void,
+    existingLabels: GHLabel[],
+    prAction: PRAction
+  ) {
+    const labelNamesToRemove: string[] = LabelService.extractLabelNames(
+      LabelCollectionType.PRCollection,
+      existingLabels
+    );
+    const labelNamesToAdd: string[] = [];
+    switch (prAction) {
+      case PRAction.READY_FOR_REVIEW:
+      case PRAction.OPENED:
+        labelNamesToAdd.push(LABEL_ARCHIVE.getLabel(LabelCollectionType.PRCollection, LabelAction.ToReview)?.name!);
+        break;
+      case PRAction.CONVERTED_TO_DRAFT:
+        labelNamesToAdd.push(LABEL_ARCHIVE.getLabel(LabelCollectionType.PRCollection, LabelAction.OnGoing)?.name!);
+        break;
     }
 
+    labelReplacer(labelNamesToRemove, labelNamesToAdd);
+  }
 }

--- a/src/services/prService.ts
+++ b/src/services/prService.ts
@@ -1,0 +1,9 @@
+import { Label } from './labelService';
+
+export class PRService {
+
+    public assignLabel(label: Label | Label[], prLabeller: (s: string) => void) {
+
+    }
+
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,8 +36,8 @@
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    "noUnusedLocals": false /* Report errors on unused locals. */,
-    "noUnusedParameters": false /* Report errors on unused parameters. */,
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    "noUnusedParameters": true /* Report errors on unused parameters. */,
     "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
 


### PR DESCRIPTION
## PR Content
### Labelling
The bot is now able to add and remove labels to PRs based on the type of action taken with them (i.e. Converted to Draft, Opened). Only some basic actions have been setup but with the basic infrastructure in place, adding more should be far easier.
### Major Re-Writes
With growing code length I added some prettier configs to run within VSCode. Maybe i'll try to integrate some CI with prettier and a specific tsconfig check for more developing flexibility. Alot more abstraction has been add (and will be added in the future) to drastically reduce the size of `index.ts` and off-load logic to other parts of the code. This will also allow to add complexity to the bot.

